### PR TITLE
Fixes #6 by changing regex for grid row units and removing rounding

### DIFF
--- a/rulecomputer.js
+++ b/rulecomputer.js
@@ -9,7 +9,7 @@ module.exports = ruleComputer;
 */
 
 const SCALEUNIT_REGEX = /\b[0-9]+sx\b/g;
-const GRIDROW_REGEX = /\b[0-9]+gr\b/g;
+const GRIDROW_REGEX = /\b\d+\.?\d*gr\b/g;
 
 function ruleComputer (base, scaleStack, inObj, context) {
 
@@ -57,7 +57,7 @@ function valueComputer (base, scaleStack, property, value, scaleIndex) {
   });
   computedValue = computedValue.replace(GRIDROW_REGEX, function (len){
     len = len.replace('gr', '');
-    len = Math.round(parseFloat(len));
+    len = parseFloat(len);
     return len * parseFloat(scaleStack[scaleIndex].line) + base.units;
   });
   if (property === 'line-height' && (value.trim() === 'auto' || parseInt(value, 10) == '0')) {


### PR DESCRIPTION
I believe this fixes the issue @custa1200 was experiencing but I've assumed the rounding for grid row units isn't needed anywhere else, please check.